### PR TITLE
Debouncing Inputs before triggering AZUR Call

### DIFF
--- a/src/components/AzurForm.jsx
+++ b/src/components/AzurForm.jsx
@@ -46,19 +46,19 @@ export default function AzurForm({ParentPropProvider}) {
       <Flex flexDirection={["column", "column", "column", "row"]}>
         <PresetButton
           activeValue={values.partyStrengths}
-          presetData={bundestagMandatsverteilung.data}
+          presetData={bundestagMandatsverteilung.btw2021}
           attributeName={"partyStrengths"}
           setFieldValue={setFieldValue}
         >
-          Aktuelle Bundestagsbesetzung
+          Bundestagswahl 2021
         </PresetButton>
         <PresetButton
           activeValue={values.partyStrengths}
-          presetData={{ a: 100 }} //TODO old bundestag
+          presetData={bundestagMandatsverteilung.btw2017}
           attributeName={"partyStrengths"}
           setFieldValue={setFieldValue}
         >
-          Mandatsprognose (INSA)
+          Bundestagswahl 2017
         </PresetButton>
       </Flex>
 
@@ -120,7 +120,7 @@ export default function AzurForm({ParentPropProvider}) {
             <PresetButton
               key={method.apiName}
               activeValue={values.method}
-              presetData={method.apiName} //TODO old bundestag
+              presetData={method.apiName}
               attributeName={"method"}
               setFieldValue={setFieldValue}
             >

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -16,9 +16,9 @@ AzurInputs.propTypes = {
 function AzurInputs({ azurInput, setAzurInput, ...cssprops }) {
   // Initial Values
   const initialValues = {
-    numSeats: 22,
+    numSeats: 25,
     method: "schepers",
-    partyStrengths: bundestagMandatsverteilung.data,
+    partyStrengths: bundestagMandatsverteilung.btw2021,
   };
 
   // Validation Scheme

--- a/src/constants/bundestagMandate.json
+++ b/src/constants/bundestagMandate.json
@@ -1,17 +1,16 @@
 {
-  "lastUpdate": "10.Sep.2021",
-  "data": [
+  "btw2017" : [
     {
       "name": "CDU/CSU",
-      "strength": 245
+      "strength": 246
     },
     {
       "name": "SPD",
-      "strength": 152
+      "strength": 153
     },
     {
       "name": "AfD",
-      "strength": 87
+      "strength": 94
     },
     {
       "name": "FDP",
@@ -25,5 +24,32 @@
       "name": "Bündnis 90/Die Grünen",
       "strength": 67
     }
+  ],
+  "btw2021" : [
+    {
+      "name": "SPD",
+      "strength": 206
+    },
+    {
+      "name": "CDU/CSU",
+      "strength": 196
+    },
+    {
+      "name": "Bündnis 90/Die Grünen",
+      "strength": 118
+    },
+    {
+      "name": "FDP",
+      "strength": 92
+    },
+    {
+      "name": "AfD",
+      "strength": 83
+    },
+    {
+      "name": "Die Linke",
+      "strength": 39
+    }
   ]
+
 }


### PR DESCRIPTION
**Issue**: Any input change used to trigger a backend call. If people would e.g. type a party name with 10 letters, 10 calls would be made. This just creates too much traffic.

**Solution**: Calls are only made if no additional input has been made in the last 700ms (tweakable var). -> "Debouncing"

**Also**: Added new Presets for 2021 Bundestagswahl